### PR TITLE
fix naming of checkmake ci workflow

### DIFF
--- a/.github/workflows/checkmake.yaml
+++ b/.github/workflows/checkmake.yaml
@@ -1,4 +1,4 @@
-name: ShellCheck
+name: CheckMake
 on:
   push:
     tags:


### PR DESCRIPTION

The CheckMake workflow was wrongly reported as `ShellCheck/CheckMake`.  This fixes it to `CheckMake/CheckMake`. 